### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,9 +2,17 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: eda-insights-2
+  tags:
+    - ansible
+    - ansible-playbook
   annotations:
     github.com/project-slug: craig-br/eda-insights-2
+  links:
+    - url: https://devspaces.apps.y1a9e1j9r7y1i8l.cbm5.p1.openshiftapps.com/#https://github.com/parasol-dev/parasol-network-playbooks
+      title: Open in Ansible development workspaces
+      icon: web
 spec:
-  type: other
-  lifecycle: unknown
-  owner: craig-br
+  owner: user:default:craig-br
+  type: playbook-project
+  system: system:default/linux-systems
+  lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: eda-insights-2
+  annotations:
+    github.com/project-slug: craig-br/eda-insights-2
+spec:
+  type: other
+  lifecycle: unknown
+  owner: craig-br

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,10 +7,6 @@ metadata:
     - ansible-playbook
   annotations:
     github.com/project-slug: craig-br/eda-insights-2
-  links:
-    - url: https://devspaces.apps.y1a9e1j9r7y1i8l.cbm5.p1.openshiftapps.com/#https://github.com/parasol-dev/parasol-network-playbooks
-      title: Open in Ansible development workspaces
-      icon: web
 spec:
   owner: user:default:craig-br
   type: playbook-project


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Parasol Red Hat Developer Hub software catalog](https://redhat-developer-hub-rhdh-ansible.apps.y1a9e1j9r7y1i8l.cbm5.p1.openshiftapps.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).